### PR TITLE
Forcing C++11 support in all of Cyborg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,10 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_DEFAULT_SOURCE")
 # no overflow warnings because of silly coin-ness
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overflow")
 
+# ORIGEN requires C++11
+SET(CMAKE_CXX_STANDARD 11)
+SET(CXX_STANDARD_REQUIRED ON )
+
 # Direct any out-of-source builds to this directory
 SET(STUB_SOURCE_DIR ${CMAKE_SOURCE_DIR})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,6 @@
 #################################################################
 ######### build libOrigenInterface ##############################
 #################################################################
-# add unit tests
-enable_testing()
 
 INCLUDE_DIRECTORIES(
     "${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
Required by ORIGEN dependency; still gives ugly warnings but appears to compile when ORIGEN interface header has been added.